### PR TITLE
fix compatibility and make getHardness faster.

### DIFF
--- a/src/main/java/xyz/luisch444/carpet/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/xyz/luisch444/carpet/mixin/AbstractBlockStateMixin.java
@@ -1,6 +1,7 @@
 package xyz.luisch444.carpet.mixin;
 
 import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;

--- a/src/main/java/xyz/luisch444/carpet/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/xyz/luisch444/carpet/mixin/AbstractBlockStateMixin.java
@@ -5,19 +5,23 @@ import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import xyz.luisch444.carpet.ZickCarpetSettings;
 
 @Mixin(AbstractBlock.AbstractBlockState.class)
-public class AbstractBlockStateMixin {
-
+public abstract class AbstractBlockStateMixin {
+    
+    @Shadow
+    public abstract Block getBlock();
+    
     @Inject(method = "getHardness", at = @At("HEAD"), cancellable = true)
     public void changeHardness(BlockView world, BlockPos pos, CallbackInfoReturnable<Float> ci) {
-        if (world.getBlockState(pos).getBlock().equals(Blocks.END_STONE) && ZickCarpetSettings.EndStonelessHardness) {
+        if (getBlock().equals(Blocks.END_STONE) && ZickCarpetSettings.EndStonelessHardness) {
             ci.setReturnValue(1.5f);
-        } else if (world.getBlockState(pos).getBlock().equals(Blocks.DEEPSLATE) && ZickCarpetSettings.deepSlateInstaminable) {
+        } else if (getBlock().equals(Blocks.DEEPSLATE) && ZickCarpetSettings.deepSlateInstaminable) {
             ci.setReturnValue(1.5f);
         }
     }


### PR DESCRIPTION
my mod jsmacros was incompatible with this mod when using the `getHardness` function, when looking closer I was passing null's in as vanilla never actually uses the passed objects...
when deciding whether I should fix this, I pulled up your code and `world.getBlockState(pos)` is literally equivalent to `this.` so this fixes my compatibility and makes this faster.